### PR TITLE
Refactor index.md content into _data YAML files

### DIFF
--- a/_data/articles.yml
+++ b/_data/articles.yml
@@ -1,0 +1,22 @@
+- title: Supercharge Your LLM Apps Using DSPy and Langfuse
+  url: https://medium.com/data-science/supercharge-your-llm-apps-using-dspy-and-langfuse-f83c02ba96a1
+- title: "Efficient Object Detection with SSD and YoLO Models \u2014 A Comprehensive Beginner\u2019s Guide (Part 3)"
+  url: https://medium.com/towards-data-science/exploring-object-detection-with-r-cnn-models-a-comprehensive-beginners-guide-part-2-685bc89775e2
+- title: "Towards DataScience: Exploring Object Detection with R-CNN Models \u2014 A Comprehensive Beginner\u2019s Guide (Part 2)"
+  url: https://medium.com/towards-data-science/exploring-object-detection-with-r-cnn-models-a-comprehensive-beginners-guide-part-2-685bc89775e2
+- title: "Towards DataScience: Object Detection Basics\u200A\u2014\u200AA Comprehensive Beginner\u2019s Guide (Part 1)"
+  url: https://medium.com/towards-data-science/object-detection-basics-a-comprehensive-beginners-guide-part-1-f57380c89b78
+- title: 'Towards DataScience: Supercharge Training of your Deep Learning Models'
+  url: https://medium.com/towards-data-science/supercharge-training-of-your-deep-learning-models-7168ff81a042
+- title: PyDev of the Week
+  url: https://www.blog.pythonlibrary.org/2021/06/14/pydev-of-the-week-raghav-bali/
+- title: 'Towards DataScience: Supercharge Image Classification with Transfer Learning'
+  url: https://towardsdatascience.com/supercharge-image-classification-with-transfer-learning-4b8c52e69c0c
+- title: 'Towards DataScience: Supercharge your Image Search with Transfer Learning'
+  url: https://towardsdatascience.com/supercharge-your-image-search-with-transfer-learning-75dfb5d29ceb
+- title: 'Towards DataScience: LSTMs for Music Generation'
+  url: https://towardsdatascience.com/lstms-for-music-generation-8b65c9671d35
+- title: 'Perceptron : Where It All Started'
+  url: https://medium.com/@Rghv_Bali/perceptron-where-it-all-started-55d3508e38af
+- title: Interview with Raghav Bali, Senior Data Scientist, United Health Group
+  url: https://www.digitalvidya.com/blog/interview-with-raghav-bali/

--- a/_data/authored_books.yml
+++ b/_data/authored_books.yml
@@ -1,0 +1,33 @@
+- url: https://www.amazon.com/Generative-Python-PyTorch-Hands-cutting-edge-ebook/dp/B0D9M8N5R3?ref_=ast_author_dp&dib=eyJ2IjoiMSJ9.lV51H7SsqpmNzyMDBg58LORh1cYJqv4cxnkrwLc-m-L8ZCeP4Z5tV-eAUmV4XtoTT0fccUgSgu8YEYkRjp-TLESxd2Ug5dtvzodc-MRASesr6gdFKkb0TD05vndRk37t.187qf5Y45cMx7rx9z9dGpzQCMn6cn6x5FADvSZ0FoE8&dib_tag=AUTHOR
+  title: Generative AI with Python and PyTorch
+  github: https://github.com/PacktPublishing/Generative-AI-with-Python-and-PyTorch-Second-Edition
+  image: /img/books/packt_gai_2.png
+- url: https://www.amazon.in/gp/product/B0922PCNPS/ref=dbs_a_def_rwt_hsch_vapi_tkin_p1_i0
+  title: Generative AI with Python and TensorFlow 2
+  github: https://github.com/PacktPublishing/Hands-On-Generative-AI-with-Python-and-TensorFlow-2
+  image: /img/books/packt_gai.jpg
+- url: https://www.amazon.in/Hands-Transfer-Learning-Python-TensorFlow/dp/1788831306/ref=sr_1_1?crid=2B3KOSW5ZHL2V&keywords=transfer+learning+python&qid=1560081081&s=gateway&sprefix=Transfer+Learnin%2Caps%2C275&sr=8-1
+  title: Hands-On Transfer Learning with Python
+  github: https://github.com/raghavbali/hands-on-transfer-learning-with-python
+  image: /img/books/packt_TL.jpg
+- url: https://www.amazon.in/Practical-Machine-Learning-Python-Problem-Solvers-ebook/dp/B077G9XF7B/ref=sr_1_3?dchild=1&keywords=Practical+Machine+Learning+with+Python&qid=1620371405&sr=8-3
+  title: Practical Machine Learning with Python
+  github: https://github.com/raghavbali/practical-machine-learning-with-python
+  image: /img/books/apress_pml.jpg
+- url: https://www.amazon.in/gp/product/B01MQ4M4VO/ref=dbs_a_def_rwt_hsch_vapi_tkin_p1_i5
+  title: 'R: Unleash Machine Learning Techniques'
+  image: /img/books/r_umlt.jpg
+- url: https://www.amazon.in/gp/product/B06XX4G463/ref=dbs_a_def_rwt_hsch_vapi_tkin_p1_i6
+  title: 'R: Complete Machine Learning Solutions'
+  image: /img/books/r_cmls.jpg
+- url: https://www.amazon.com/Learning-Social-Media-Analytics-actionable/dp/1787127524/ref=sr_1_1?ie=UTF8&qid=1509264422&sr=8-1&keywords=learning+social+media+analytics+with+R
+  title: Learning Social Media Analytics with R
+  github: https://github.com/raghavbali/learning-social-media-analytics-with-r
+  image: /img/books/packt_sma_r.jpg
+- url: https://www.amazon.in/Machine-Learning-Example-Raghav-Bali-ebook/dp/B01A14X6KA
+  title: R Machine Learning by Example
+  github: https://github.com/raghavbali/r_machine_learning_by_example
+  image: /img/books/packt_rml.jpg
+- url: https://github.com/raghavbali/raghavbali.github.io/raw/master/_backup_site/public/What%20you%20need%20to%20know%20about%20R%20%5BeBook%5D.pdf
+  title: 'Free eBook: What You Need To Know About R'
+  image: /img/books/packt_wyntar.png

--- a/_data/news.yml
+++ b/_data/news.yml
@@ -1,0 +1,32 @@
+- year: '2025'
+  content: '[Generative AI with Python & Pytorch Second Edition Published](https://www.amazon.com/Generative-Python-PyTorch-Hands-cutting-edge/dp/B0D9QBYYBQ/?_encoding=UTF8&pd_rd_w=BdKvt&content-id=amzn1.sym.0fb2cce1-1ca4-439a-844b-8ad0b1fb77f7&pf_rd_p=0fb2cce1-1ca4-439a-844b-8ad0b1fb77f7&pf_rd_r=142-1639174-8459023&pd_rd_wg=mtZj1&pd_rd_r=28d75a7b-4588-4838-b7eb-433b3f187551&ref_=aufs_ap_sc_dsk)'
+- year: '2023'
+  content: '[Generative AI with Python & Tensorflow2 listed as a Must Read book by AIM](https://analyticsindiamag.com/7-must-read-generative-ai-books-for-unleashing-your-technology-prowess/)'
+- year: '2023'
+  content: '[Lightening Interview with Sheamus McGovern](https://app.aiplus.training/courses/Hands-On-Generative-AI-Applications)'
+- year: '2021'
+  content: '[Interviewed/Featured on Mike Dris Collis'' Blog Mouse Vs Python](https://www.blog.pythonlibrary.org/2021/06/14/pydev-of-the-week-raghav-bali/)'
+- year: '2021'
+  content: Runner's Up, Global Data Science Hackathon, Optum
+- year: '2021'
+  content: Awarded Honory title of __Senior Inventor__ for several contributions to patent program in 2020, Optum
+- year: '2021'
+  content: Innovation Award Winner for Q1 2021, Optum
+- year: '2020'
+  content: Runner's Up, Global Data Science Hackathon, Optum
+- year: '2020'
+  content: Award for Exemplary Leadership, Optum
+- year: '2018'
+  content: Runner's Up, Global Data Science Hackathon, Optum
+- year: '2017'
+  content: Best Paper Presentation Award at ITTLC, Intel
+- year: '2014'
+  content: Awarded Gold Medal (Late Sri N Rama Rao Medal- Student of the Year), IIIT-B
+- year: 2013-14
+  content: Google Student Ambassador
+- year: '2013'
+  content: Dean's Merit List, 3rd Semester, IIIT-B
+- year: '2013'
+  content: Dean's Merit List, 2nd Semester, IIIT-B
+- year: '2012'
+  content: Dean's Merit List, 1st Semester, IIIT-B

--- a/_data/papers.yml
+++ b/_data/papers.yml
@@ -1,0 +1,62 @@
+- id: /dhrd
+  title: 'Delivery Hero Recommendation Dataset: A Novel Dataset for Benchmarking Recommendation Algorithms'
+  conference: ACM Recsys 2023
+  authors: Yernat Assylbekov, Raghav Bali, Luke Bovard and Christian Klaue.
+  links:
+  - text: Published Version
+    url: https://dl.acm.org/doi/10.1145/3604915.3610242
+  image: /img/pubs/DHRD.png
+- id: /easter2
+  title: 'Easter2.0: Improving Convolutional Models for Handwritten Text Recognition'
+  authors: Kartik Chaudhary and Raghav Bali
+  links:
+  - text: Preprint Paper
+    url: https://arxiv.org/pdf/2205.14879
+  image: /img/pubs/easter2_arch.png
+- id: /easter
+  title: 'EASTER: Simplifying Text Recognition using only 1D Convolutions'
+  conference: CAIAC 2021
+  authors: Kartik Chaudhary and Raghav Bali
+  links:
+  - text: Preprint Paper
+    url: https://arxiv.org/pdf/2008.07839
+  - text: Published Version
+    url: https://caiac.pubpub.org/pub/fm5sy88o
+  image: /img/pubs/easter_arch.jpg
+- id: /patient1
+  title: A Simple and Interpretable Predictive Model for Healthcare
+  conference: CAIAC 2021
+  authors: Subhadip Maji, Raghav Bali, Sree Harsha Ankem and Kishore V Ayyadevara
+  links:
+  - text: Preprint Paper
+    url: https://arxiv.org/pdf/2007.13351
+  - text: Published Version
+    url: https://caiac.pubpub.org/pub/od0e1bry
+  image: /img/pubs/shap_all.jpg
+- id: /rfp1
+  title: An Interpretable Deep Learning System for Automatically Scoring Request for Proposals
+  conference: IEEE SSCI 2021
+  authors: Subhadip Maji, Anudeeo S Appe, Raghav Bali, Veera R Chikka, Arijit G Chowdhury, Vamsi M Bhandaru
+  links:
+  - text: Preprint Paper
+    url: https://arxiv.org/pdf/2008.02347
+  - text: Published Version
+    url: https://ieeexplore.ieee.org/abstract/document/9643310
+  image: /img/pubs/rfp1.png
+- id: /rfp2
+  title: Exclusion and Inclusion--A model agnostic approach to feature importance in DNNs
+  conference: IEEE ICTAI 2021
+  authors: Subhadip Maji, Arijit Ghosh Chowdhury, Raghav Bali, Vamsi M Bhandaru
+  links:
+  - text: Preprint Paper
+    url: https://arxiv.org/pdf/2007.16010
+  - text: Published Version
+    url: https://ieeexplore.ieee.org/abstract/document/9659843
+  image: /img/pubs/rfp2.png
+- id: /firewall
+  title: Real Time Failure Prediction of Load Balancers and Firewalls
+  conference: IEEE Smart Data (SmartData) 2016
+  authors: Tamoghna Ghosh, Dipanjan Sarkar, Tushar Sharma, Ashok Desai, Raghav Bali
+  links:
+  - text: Published Version
+    url: https://ieeexplore.ieee.org/abstract/document/7917199

--- a/_data/patents.yml
+++ b/_data/patents.yml
@@ -1,0 +1,66 @@
+- id: /patent1
+  title: Cybersecurity for sensitive-information utterances in interactive voice sessions
+  patent_id: US11854553B2
+  authors: Devikiran Ramadas;Gregory J Boss;Ninad Sathaye;<b>Raghav Bali</b>;Nitin Dwivedi
+  url: https://patents.google.com/patent/US11854553B2/en?inventor=Raghav+Bali
+  status: Granted
+- id: /patent2
+  title: Machine learning techniques for natural language processing using predictive entity scoring
+  patent_id: US11853700B1
+  authors: Nathan H. Funk;Eric D. Tryon;Amy L. Jensen;Sudheer Ponnala;M. P. S. Jagannadha Rao;<b>Raghav Bali</b>;Veera Raghavendra Chikka;Subhadip Maji;Anudeep Srivatsav Appe
+  url: https://patents.google.com/patent/US11853700B1/en?inventor=Raghav+Bali
+  status: Granted
+- id: /patent3
+  title: Dynamic triggering of augmented reality assistance mode functionalities
+  patent_id: US11663790B2
+  authors: Kartik Chaudhary;Sudeep Choudhary;<b>Raghav Bali</b>;Anurag Das;Subhadip Maji
+  url: https://patents.google.com/patent/US11663790B2/en?inventor=Raghav+Bali
+  status: Granted
+- id: /patent4
+  title: Weighted adaptive filtering based loss function to predict the first occurrence of multiple events in a single shot
+  patent_id: US11741381B2
+  authors: V Kishore Ayyadevara;Sree Harsha Ankem;<b>Raghav Bali</b>;Rohan Khilnani;Vineet Shukla;Saikumar Chintareddy;Ranraj Rana Singh
+  url: https://patents.google.com/patent/US11741381B2/en?inventor=Raghav+Bali
+  status: Granted
+- id: /patent5
+  title: Sentiment progression analysis
+  patent_id: US11256874B2
+  authors: Ninad D. Sathaye;<b>Raghav Bali</b>;Piyush Gupta;Krishnamohan Nandiraju
+  url: https://patents.google.com/patent/US11256874B2/en?inventor=Raghav+Bali
+  status: Granted
+- id: /patent6
+  title: Cybersecurity for sensitive-information utterances in interactive voice sessions using risk profiles
+  patent_id: US20220199073A1
+  authors: Devikiran Ramadas;Gregory J Boss;Ninad Sathaye;<b>Raghav Bali</b>;Nitin Dwivedi
+  url: https://patents.google.com/patent/US20220199073A1/en?inventor=Raghav+Bali
+  status: Pending
+- id: /patent7
+  title: Routing of sensitive-information utterances through secure channels in interactive voice sessions
+  patent_id: US20230269291A1
+  authors: Devikiran Ramadas;Ninad D. Sathaye;Gregory J. Boss;<b>Raghav Bali</b>
+  url: https://patents.google.com/patent/US20230269291A1/en?inventor=Raghav+Bali
+  status: Pending
+- id: /patent8
+  title: Systems and methods for awakening a user based on sleep cycle
+  patent_id: US20230059947A1
+  authors: <b>Raghav Bali</b>;Ninad D. Sathaye;Swapna Sourav Rout
+  url: https://patents.google.com/patent/US20230059947A1/en?inventor=Raghav+Bali
+  status: Pending
+- id: /patent9
+  title: Reinforcement learning machine learning models for intervention recommendation
+  patent_id: US20230252338A1
+  authors: V. Kishore Ayyadevara;Rohan Khilnani;Swaroop S. Shekar;<b>Raghav Bali</b>;Joseph C. Cremaldi;Fritz T. Wilhelm;Vinod Burugupalli
+  url: https://patents.google.com/patent/US20230252338A1/en?inventor=Raghav+Bali
+  status: Pending
+- id: /patent10
+  title: Predictive document conversion
+  patent_id: US20210326631A1
+  authors: Kartik Chaudhary;<b>Raghav Bali</b>;V Kishore Ayyadevara;Yerraguntla Yeshwanth Reddy
+  url: https://patents.google.com/patent/US20210326631A1/en?inventor=Raghav+Bali
+  status: Pending
+- id: /patent11
+  title: Predictive data analysis operations using a hierarchical intervention recommendation machine learning framework
+  patent_id: US20230325690A1
+  authors: Ninad D. Sathaye;Manoj Kapoor;Gregory J. Boss;<b>Raghav Bali</b>
+  url: https://patents.google.com/patent/US20230325690A1/en?inventor=Raghav+Bali
+  status: Pending

--- a/_data/reviewed_books.yml
+++ b/_data/reviewed_books.yml
@@ -1,0 +1,8 @@
+- title: Deep Learning with TensorFlow and Keras By Antonio Gulli et. al. - Third Edition
+  url: https://www.amazon.com/Deep-Learning-TensorFlow-Keras-reinforcement/dp/1803232919
+- title: Python Machine Learning By Example By Yuxi (Hayden) Liu - Third Edition
+  url: https://www.amazon.in/Python-Machine-Learning-Example-scikit-learn/dp/1800209711
+- title: Python Machine Learning By Sebastian Raschka - 3rd Edition
+  url: https://www.linkedin.com/posts/activity-6611163258529423360-qzDY
+- title: Machine Learning with R by Brett Lantz - 3rd Edition
+  url: https://www.linkedin.com/posts/baliraghav_machinelearning-datascience-datamining-activity-6549159041422192640-8PH5

--- a/_data/talks.yml
+++ b/_data/talks.yml
@@ -1,0 +1,104 @@
+- year: '2025'
+  title: 'Mastering LLMs: Training, Fine-Tuning, and Best Practices'
+  url: https://www.analyticsvidhya.com/datahacksummit-2025/workshops/mastering-llms-training-fine-tuning-and-best-practices-2
+  links:
+  - text: Github
+    url: https://github.com/raghavbali/mastering_llms_workshop
+  - text: Workshop Website
+    url: https://raghavbali.github.io/mastering_llms_workshop/
+- year: '2024'
+  title: 'Unleashing LLMs: Training, Fine-Tuning and Evaluating'
+  url: https://www.analyticsvidhya.com/datahacksummit/workshops/unleashing-llms-training-finetuning-and-evaluating
+  links:
+  - text: Github
+    url: https://github.com/raghavbali/llm_workshop
+- year: '2024'
+  title: Leveraging LLLMs for Internal Knowledge Discovery
+  url: https://odsc.com/speakers/leveraging-llms-for-internal-knowledge-discovery/
+  links:
+  - text: Github
+    url: '#'
+- year: '2023'
+  title: 'ODSC APAC Session: Generative AI Landscape'
+  url: https://github.com/raghavbali/genai_landscape_odsc2023
+  links:
+  - text: Github
+    url: https://github.com/raghavbali/genai_landscape_odsc2023
+- year: '2023'
+  title: 'ON-DEMAND WEBINAR: Lightning Interview "Hands-On Generative AI Applications"'
+  url: https://app.aiplus.training/courses/Hands-On-Generative-AI-Applications
+  links:
+  - text: ODSC On-Demand
+    url: https://app.aiplus.training/courses/Hands-On-Generative-AI-Applications
+- year: '2023'
+  title: 'Analytics Vidhya DataHack Summit Workshop: Natural Language Processing using Generative Models'
+  url: https://github.com/raghavbali/llm_workshop_dhs23
+  links:
+  - text: Github
+    url: https://github.com/raghavbali/llm_workshop_dhs23
+- year: '2023'
+  title: 'Analytics Vidhya DataHack Summit Hack Session: Building Robust and Scalable Recommendation Systems for Online Food Delivery'
+  url: https://github.com/raghavbali/building_robust_recsys_dhs23
+  links:
+  - text: Github
+    url: https://github.com/raghavbali/building_robust_recsys_dhs23
+- year: '2022'
+  title: Image Generation with GANs with ODSC India
+  url: https://github.com/raghavbali/workshop_text_classification
+  links:
+  - text: Github
+    url: https://github.com/raghavbali/gan_tutorial
+- year: '2022'
+  title: NLP Workshop on Text Classification, 1729 Conference with Analytics Vidhya
+  url: https://github.com/raghavbali/workshop_text_classification
+  links:
+  - text: Github
+    url: https://github.com/raghavbali/workshop_text_classification
+- year: '2021'
+  title: Image Classification with Transfer Learning, Manning Publications Twitch Live-Stream
+  url: https://github.com/raghavbali/transfer-learning-in-action/tree/master/chapter_1
+  links:
+  - text: Video
+    url: https://www.twitch.tv/videos/1170692362
+- year: '2021'
+  title: Image Generation with GANs, Kaggle Data Ketchup
+  url: https://github.com/raghavbali/data_ketchup_gans
+  links:
+  - text: Video
+    url: https://www.youtube.com/watch?v=J_33jSkFQis&ab_channel=KaggleDaysMeetupDelhiNCR
+- year: '2021'
+  title: The Secret Ingredients to Train DeepFakes, ODSC APAC
+  url: https://github.com/raghavbali/deep_fakes_tutorial
+  links:
+  - text: Video
+    url: https://register.gotowebinar.com/register/7432238325978557965
+- year: '2020'
+  title: NLP Starter Pack, Analytics Vidhya Webinar
+  url: https://github.com/raghavbali/nlp_starterpack_webinar
+  links:
+  - text: Video
+    url: https://www.facebook.com/watch/live/?v=337463904223866&ref=watch_permalink
+- year: '2020'
+  title: Text Generation using Deep Learning, Springboard Webinar
+  url: https://github.com/raghavbali/text_generation
+  links:
+  - text: Video
+    url: https://www.youtube.com/watch?v=vSN5Tn38ZIc&ab_channel=SpringboardIndia
+- year: '2019'
+  title: 'Hack Session: Synthetic Text Data Generation using Recurrent Neural Networks (RNN)'
+  url: https://www.analyticsvidhya.com/datahack-summit-2019/schedule/hack-session-synthetic-text-data-generation-using-rnn-based-deep-learning-models/
+  links:
+  - text: GitHub
+    url: https://github.com/raghavbali/handwritten_text_dhs_av_2019
+- year: '2019'
+  title: 'Workshop: Applied Machine Learning'
+  url: https://www.analyticsvidhya.com/datahack-summit-2019/schedule/workshop-applied-machine-learning/
+  links:
+  - text: GitHub
+    url: https://github.com/raghavbali/appliedml_workshop_dhs_av_2019
+- year: '2018'
+  title: 'Workshop: Getting Started With Natural Language Processing'
+  url: https://www.analyticsvidhya.com/datahack-summit-2018/2018/08/04/getting-started-with-natural-language-processing/
+  links:
+  - text: GitHub
+    url: https://github.com/raghavbali/nlp_workshop_dhs18

--- a/index.md
+++ b/index.md
@@ -51,22 +51,10 @@ permalink:  /
 <a name="/news"></a>
 # News
 
-- [2025] [Generative AI with Python & Pytorch Second Edition Published](https://www.amazon.com/Generative-Python-PyTorch-Hands-cutting-edge/dp/B0D9QBYYBQ/?_encoding=UTF8&pd_rd_w=BdKvt&content-id=amzn1.sym.0fb2cce1-1ca4-439a-844b-8ad0b1fb77f7&pf_rd_p=0fb2cce1-1ca4-439a-844b-8ad0b1fb77f7&pf_rd_r=142-1639174-8459023&pd_rd_wg=mtZj1&pd_rd_r=28d75a7b-4588-4838-b7eb-433b3f187551&ref_=aufs_ap_sc_dsk)
-- [2023] [Generative AI with Python & Tensorflow2 listed as a Must Read book by AIM](https://analyticsindiamag.com/7-must-read-generative-ai-books-for-unleashing-your-technology-prowess/)
-- [2023] [Lightening Interview with Sheamus McGovern](https://app.aiplus.training/courses/Hands-On-Generative-AI-Applications)
-- [2021] [Interviewed/Featured on Mike Dris Collis' Blog Mouse Vs Python](https://www.blog.pythonlibrary.org/2021/06/14/pydev-of-the-week-raghav-bali/)
-- [2021] Runner's Up, Global Data Science Hackathon, Optum
-- [2021] Awarded Honory title of __Senior Inventor__ for several contributions to patent program in 2020, Optum
-- [2021] Innovation Award Winner for Q1 2021, Optum
-- [2020] Runner's Up, Global Data Science Hackathon, Optum
-- [2020] Award for Exemplary Leadership, Optum
-- [2018] Runner's Up, Global Data Science Hackathon, Optum
-- [2017] Best Paper Presentation Award at ITTLC, Intel
-- [2014] Awarded Gold Medal (Late Sri N Rama Rao Medal- Student of the Year), IIIT-B
-- [2013-14] Google Student Ambassador
-- [2013] Dean's Merit List, 3rd Semester, IIIT-B
-- [2013] Dean's Merit List, 2nd Semester, IIIT-B
-- [2012] Dean's Merit List, 1st Semester, IIIT-B
+{% for item in site.data.news %}
+- [{{ item.year }}] {{ item.content }}
+{% endfor %}
+
 <!-- <div id="read-more-button"> <a nohref>Read more</a> </div> -->
 
 <!-- Back to Top Button -->
@@ -146,189 +134,62 @@ Outside of work, he’s a tech enthusiast who enjoys exploring new gadgets and i
 <a name="/papers"></a>
 
 # Papers
-<a name="/dhrd"></a>
-<h2 class="pubt">Delivery Hero Recommendation Dataset: A Novel Dataset for Benchmarking Recommendation Algorithms</h2>
+{% for paper in site.data.papers %}
+<a name="{{ paper.id }}"></a>
+<h2 class="pubt">{{ paper.title }}</h2>
 <p class="pubd">
-<span class="conf">ACM Recsys 2023</span><br> 
-    <span class="authors">Yernat Assylbekov, Raghav Bali, Luke Bovard and Christian Klaue.</span><br>
+{% if paper.conference %}
+<span class="conf">{{ paper.conference }}</span><br>
+{% endif %}
+{% if paper.authors %}
+    <span class="authors">{{ paper.authors }}</span><br>
+{% endif %}
+{% if paper.links %}
     <span class="links">
-        <a target="_blank" href="https://dl.acm.org/doi/10.1145/3604915.3610242">Published Version</a>
+        {% for link in paper.links %}
+        <a target="_blank" href="{{ link.url }}">{{ link.text }}</a>
+        {% endfor %}
     </span>
+{% endif %}
 </p>
-<img src="/img/pubs/DHRD.png">
+{% if paper.image %}
+<img src="{{ paper.image }}">
+{% endif %}
 <hr>
-<a name="/easter2"></a>
-<h2 class="pubt">Easter2.0: Improving Convolutional Models for Handwritten Text Recognition</h2>
-<p class="pubd">
-    <span class="authors">Kartik Chaudhary and Raghav Bali</span><br>
-    <span class="links">
-        <a target="_blank" href="https://arxiv.org/pdf/2205.14879">Preprint Paper</a>
-        <!-- <a target="_blank" href="https://caiac.pubpub.org/pub/fm5sy88o">Published Version</a> -->
-    </span>
-</p>
-<img src="/img/pubs/easter2_arch.png">
-<hr>
-
-<a name="/easter"></a>
-<h2 class="pubt">EASTER: Simplifying Text Recognition using only 1D Convolutions</h2>
-<p class="pubd">
-<span class="conf">CAIAC 2021</span><br>
-    <span class="authors">Kartik Chaudhary and Raghav Bali</span><br>
-    <span class="links">
-        <a target="_blank" href="https://arxiv.org/pdf/2008.07839">Preprint Paper</a>
-        <a target="_blank" href="https://caiac.pubpub.org/pub/fm5sy88o">Published Version</a>
-    </span>
-</p>
-<img src="/img/pubs/easter_arch.jpg">
-<hr>
-
-<a name="/patient1"></a>
-<h2 class="pubt">A Simple and Interpretable Predictive Model for Healthcare</h2>
-<p class="pubd">
-<span class="conf">CAIAC 2021</span><br>
-    <span class="authors">Subhadip Maji, Raghav Bali, Sree Harsha Ankem and Kishore V Ayyadevara</span><br>
-    <span class="links">
-        <a target="_blank" href="https://arxiv.org/pdf/2007.13351">Preprint Paper</a>
-        <a target="_blank" href="https://caiac.pubpub.org/pub/od0e1bry">Published Version</a>
-    </span>
-</p>
-<img src="/img/pubs/shap_all.jpg">
-<hr>
-
-<a name="/rfp1"></a>
-<h2 class="pubt">An Interpretable Deep Learning System for Automatically Scoring Request for Proposals</h2>
-<p class="pubd">
-<span class="conf">IEEE SSCI 2021</span><br>
-    <span class="authors">Subhadip Maji, Anudeeo S Appe, Raghav Bali, Veera R Chikka, Arijit G Chowdhury, Vamsi M Bhandaru</span><br>
-    <span class="links">
-        <a target="_blank" href="https://arxiv.org/pdf/2008.02347">Preprint Paper</a>
-        <a target="_blank" href="https://ieeexplore.ieee.org/abstract/document/9643310">Published Version</a>
-    </span>
-</p>
-<img src="/img/pubs/rfp1.png">
-<hr>
-
-<a name="/rfp2"></a>
-<h2 class="pubt">Exclusion and Inclusion--A model agnostic approach to feature importance in DNNs</h2>
-<p class="pubd">
-<span class="conf">IEEE ICTAI 2021</span><br>
-    <span class="authors">Subhadip Maji, Arijit Ghosh Chowdhury, Raghav Bali, Vamsi M Bhandaru</span><br>
-    <span class="links">
-        <a target="_blank" href="https://arxiv.org/pdf/2007.16010">Preprint Paper</a>
-        <a target="_blank" href="https://ieeexplore.ieee.org/abstract/document/9659843">Published Version</a>
-    </span>
-</p>
-<img src="/img/pubs/rfp2.png">
-<hr>
-
-<a name="/firewall"></a>
-<h2 class="pubt">Real Time Failure Prediction of Load Balancers and Firewalls</h2>
-<p class="pubd">
-    <span class="authors">Tamoghna Ghosh, Dipanjan Sarkar, Tushar Sharma, Ashok Desai, Raghav Bali</span><br>
-    <span class="conf">IEEE Smart Data (SmartData) 2016</span><br>
-    <span class="links">
-        <a target="_blank" href="https://ieeexplore.ieee.org/abstract/document/7917199">Published Version</a>
-    </span>
-</p>
-<hr>
+{% endfor %}
 
 
 <a name="/books"></a>
 # Books
+{% for book in site.data.authored_books %}
+  {% assign remainder = forloop.index0 | modulo: 2 %}
+  {% if remainder == 0 %}
 <div class="row">
+  {% endif %}
     <div class="col-sm-6">
-        <h2 class="talkt" style="font-weight:300;"><a target="_blank" href="https://www.amazon.com/Generative-Python-PyTorch-Hands-cutting-edge-ebook/dp/B0D9M8N5R3?ref_=ast_author_dp&dib=eyJ2IjoiMSJ9.lV51H7SsqpmNzyMDBg58LORh1cYJqv4cxnkrwLc-m-L8ZCeP4Z5tV-eAUmV4XtoTT0fccUgSgu8YEYkRjp-TLESxd2Ug5dtvzodc-MRASesr6gdFKkb0TD05vndRk37t.187qf5Y45cMx7rx9z9dGpzQCMn6cn6x5FADvSZ0FoE8&dib_tag=AUTHOR">Generative AI with Python and PyTorch</a></h2>
-        <span class="conf"><a href="https://github.com/PacktPublishing/Generative-AI-with-Python-and-PyTorch-Second-Edition">Github</a></span>
+        <h2 class="talkt" style="font-weight:300;"><a target="_blank" href="{{ book.url }}">{{ book.title }}</a></h2>
+        {% if book.github %}
+        <span class="conf"><a href="{{ book.github }}">Github</a></span>
+        {% endif %}
         <p class="talkd">
-            <a target="_blank" href="https://www.amazon.com/Generative-Python-PyTorch-Hands-cutting-edge-ebook/dp/B0D9M8N5R3?ref_=ast_author_dp&dib=eyJ2IjoiMSJ9.lV51H7SsqpmNzyMDBg58LORh1cYJqv4cxnkrwLc-m-L8ZCeP4Z5tV-eAUmV4XtoTT0fccUgSgu8YEYkRjp-TLESxd2Ug5dtvzodc-MRASesr6gdFKkb0TD05vndRk37t.187qf5Y45cMx7rx9z9dGpzQCMn6cn6x5FADvSZ0FoE8&dib_tag=AUTHOR"><img style="margin-top: 10px;" src="/img/books/packt_gai_2.png"></a>
+            <a target="_blank" href="{{ book.url }}"><img style="margin-top: 10px;" src="{{ book.image }}"></a>
         </p>
     </div>
-    <div class="col-sm-6">
-        <h2 class="talkt" style="font-weight:300;"><a target="_blank" href="https://www.amazon.in/gp/product/B0922PCNPS/ref=dbs_a_def_rwt_hsch_vapi_tkin_p1_i0">Generative AI with Python and TensorFlow 2</a></h2>
-        <span class="conf"><a href="https://github.com/PacktPublishing/Hands-On-Generative-AI-with-Python-and-TensorFlow-2">Github</a></span>
-        <p class="talkd">
-            <a target="_blank" href="https://www.amazon.in/gp/product/B0922PCNPS/ref=dbs_a_def_rwt_hsch_vapi_tkin_p1_i0"><img style="margin-top: 10px;" src="/img/books/packt_gai.jpg"></a>
-        </p>
-    </div>
+  {% if remainder == 1 or forloop.last %}
 </div>
-<div class="row">
-    <div class="col-sm-6">
-        <h2 class="talkt" style="font-weight:300;"><a target="_blank" href="https://www.amazon.in/Hands-Transfer-Learning-Python-TensorFlow/dp/1788831306/ref=sr_1_1?crid=2B3KOSW5ZHL2V&keywords=transfer+learning+python&qid=1560081081&s=gateway&sprefix=Transfer+Learnin%2Caps%2C275&sr=8-1">Hands-On Transfer Learning with Python</a></h2>
-        <span class="conf"><a href="https://github.com/raghavbali/hands-on-transfer-learning-with-python">Github</a></span>
-        <p class="talkd">
-            <a target="_blank" href="https://www.amazon.in/Hands-Transfer-Learning-Python-TensorFlow/dp/1788831306/ref=sr_1_1?crid=2B3KOSW5ZHL2V&keywords=transfer+learning+python&qid=1560081081&s=gateway&sprefix=Transfer+Learnin%2Caps%2C275&sr=8-1"><img style="margin-top: 10px;" src="/img/books/packt_TL.jpg"></a>
-        </p>
-    </div>
-    <div class="col-sm-6">
-        <h2 class="talkt" style="font-weight:300;"><a target="_blank" href="https://www.amazon.in/Practical-Machine-Learning-Python-Problem-Solvers-ebook/dp/B077G9XF7B/ref=sr_1_3?dchild=1&keywords=Practical+Machine+Learning+with+Python&qid=1620371405&sr=8-3">Practical Machine Learning with Python</a></h2>
-        <span class="conf"><a href="https://github.com/raghavbali/practical-machine-learning-with-python">Github</a></span>
-        <p class="talkd">
-            <a target="_blank" href="https://www.amazon.in/Practical-Machine-Learning-Python-Problem-Solvers-ebook/dp/B077G9XF7B/ref=sr_1_3?dchild=1&keywords=Practical+Machine+Learning+with+Python&qid=1620371405&sr=8-3"><img style="margin-top: 10px;" src="/img/books/apress_pml.jpg"></a>
-        </p>
-    </div>
-</div>
-<div class="row">
-    <div class="col-sm-6">
-        <h2 class="talkt" style="font-weight:300;"><a target="_blank" href="https://www.amazon.in/gp/product/B01MQ4M4VO/ref=dbs_a_def_rwt_hsch_vapi_tkin_p1_i5">R: Unleash Machine Learning Techniques</a></h2>
-        <p class="talkd">
-            <a target="_blank" href="https://www.amazon.in/gp/product/B01MQ4M4VO/ref=dbs_a_def_rwt_hsch_vapi_tkin_p1_i5"><img style="margin-top: 10px;" src="/img/books/r_umlt.jpg"></a>
-        </p>
-    </div>
-    <div class="col-sm-6">
-        <h2 class="talkt" style="font-weight:300;"><a target="_blank" href="https://www.amazon.in/gp/product/B06XX4G463/ref=dbs_a_def_rwt_hsch_vapi_tkin_p1_i6">R: Complete Machine Learning Solutions</a></h2>
-        <p class="talkd">
-            <a target="_blank" href="https://www.amazon.in/gp/product/B06XX4G463/ref=dbs_a_def_rwt_hsch_vapi_tkin_p1_i6"><img style="margin-top: 10px;" src="/img/books/r_cmls.jpg"></a>
-        </p>
-    </div>
-</div>
-<div class="row">
-    <div class="col-sm-6">
-        <h2 class="talkt" style="font-weight:300;"><a target="_blank" href="https://www.amazon.com/Learning-Social-Media-Analytics-actionable/dp/1787127524/ref=sr_1_1?ie=UTF8&qid=1509264422&sr=8-1&keywords=learning+social+media+analytics+with+R">Learning Social Media Analytics with R</a></h2>
-        <span class="conf"><a href="https://github.com/raghavbali/learning-social-media-analytics-with-r">Github</a></span>
-        <p class="talkd">
-            <a target="_blank" href="https://www.amazon.com/Learning-Social-Media-Analytics-actionable/dp/1787127524/ref=sr_1_1?ie=UTF8&qid=1509264422&sr=8-1&keywords=learning+social+media+analytics+with+R"><img style="margin-top: 10px;" src="/img/books/packt_sma_r.jpg"></a>
-        </p>
-    </div>
-    <div class="col-sm-6">
-        <h2 class="talkt" style="font-weight:300;"><a target="_blank" href="https://www.amazon.in/Machine-Learning-Example-Raghav-Bali-ebook/dp/B01A14X6KA">R Machine Learning by Example</a></h2>
-        <span class="conf"><a href="https://github.com/raghavbali/r_machine_learning_by_example">Github</a></span>
-        <p class="talkd">
-            <a target="_blank" href="https://www.amazon.in/Machine-Learning-Example-Raghav-Bali-ebook/dp/B01A14X6KA"><img style="margin-top: 10px;" src="/img/books/packt_rml.jpg"></a>
-        </p>
-    </div>
-</div>
-<div class="row">
-    <div class="col-sm-6">
-        <h2 class="talkt" style="font-weight:300;"><a target="_blank" href="https://github.com/raghavbali/raghavbali.github.io/raw/master/_backup_site/public/What%20you%20need%20to%20know%20about%20R%20%5BeBook%5D.pdf">Free eBook: What You Need To Know About R</a></h2>
-        <p class="talkd">
-            <a target="_blank" href="https://github.com/raghavbali/raghavbali.github.io/raw/master/_backup_site/public/What%20you%20need%20to%20know%20about%20R%20%5BeBook%5D.pdf"><img style="margin-top: 10px;" src="/img/books/packt_wyntar.png"></a>
-        </p>
-    </div>
-</div>
+  {% endif %}
+{% endfor %}
 
 # Books Reviewed
 <div class="row">
     <div class="col-xs-12">
+        {% for book in site.data.reviewed_books %}
         <div class="talkt">
-                <a target="_blank" href="https://www.amazon.com/Deep-Learning-TensorFlow-Keras-reinforcement/dp/1803232919">
-                    Deep Learning with TensorFlow and Keras By Antonio Gulli et. al. - Third Edition
+                <a target="_blank" href="{{ book.url }}">
+                    {{ book.title }}
                 </a>
         </div>
-        <div class="talkt">
-                <a target="_blank" href="https://www.amazon.in/Python-Machine-Learning-Example-scikit-learn/dp/1800209711">
-                    Python Machine Learning By Example By Yuxi (Hayden) Liu - Third Edition
-                </a>
-        </div>
-        <div class="talkt">
-                <a target="_blank" href="https://www.linkedin.com/posts/activity-6611163258529423360-qzDY">
-                    Python Machine Learning By Sebastian Raschka - 3rd Edition
-                </a>
-        </div>
-        <div class="talkt">
-                <a target="_blank" href="https://www.linkedin.com/posts/baliraghav_machinelearning-datascience-datamining-activity-6549159041422192640-8PH5">
-                    Machine Learning with R by Brett Lantz - 3rd Edition
-                </a>
-        </div>
+        {% endfor %}
     </div>
 </div>
 <hr>
@@ -336,116 +197,20 @@ Outside of work, he’s a tech enthusiast who enjoys exploring new gadgets and i
 <a name="/patents"></a>
 
 # Patents
-<a name="/patent1"></a>
-<h2 class="pubt">Cybersecurity for sensitive-information utterances in interactive voice sessions</h2>
+{% for patent in site.data.patents %}
+<a name="{{ patent.id }}"></a>
+<h2 class="pubt">{{ patent.title }}</h2>
 <p class="pubd">
-<span class="conf">US11854553B2</span><br> 
-    <span class="authors">Devikiran Ramadas;Gregory J Boss;Ninad Sathaye;<b>Raghav Bali</b>;Nitin Dwivedi</span><br>
+{% if patent.patent_id %}
+<span class="conf">{{ patent.patent_id }}</span><br>
+{% endif %}
+    <span class="authors">{{ patent.authors }}</span><br>
     <span class="links">
-        <a target="_blank" href="https://patents.google.com/patent/US11854553B2/en?inventor=Raghav+Bali">Granted</a>
+        <a target="_blank" href="{{ patent.url }}">{{ patent.status }}</a>
     </span>
 </p>
 <hr>
-<a name="/patent2"></a>
-<h2 class="pubt">Machine learning techniques for natural language processing using predictive entity scoring</h2>
-<p class="pubd">
-<span class="conf">US11853700B1</span><br> 
-    <span class="authors">Nathan H. Funk;Eric D. Tryon;Amy L. Jensen;Sudheer Ponnala;M. P. S. Jagannadha Rao;<b>Raghav Bali</b>;Veera Raghavendra Chikka;Subhadip Maji;Anudeep Srivatsav Appe</span><br>
-    <span class="links">
-        <a target="_blank" href="https://patents.google.com/patent/US11853700B1/en?inventor=Raghav+Bali">Granted</a>
-    </span>
-</p>
-<hr>
-<a name="/patent3"></a>
-<h2 class="pubt">Dynamic triggering of augmented reality assistance mode functionalities</h2>
-<p class="pubd">
-<span class="conf">US11663790B2</span><br> 
-    <span class="authors">Kartik Chaudhary;Sudeep Choudhary;<b>Raghav Bali</b>;Anurag Das;Subhadip Maji</span><br>
-    <span class="links">
-        <a target="_blank" href="https://patents.google.com/patent/US11663790B2/en?inventor=Raghav+Bali">Granted</a>
-    </span>
-</p>
-<hr>
-<a name="/patent4"></a>
-<h2 class="pubt">Weighted adaptive filtering based loss function to predict the first occurrence of multiple events in a single shot</h2>
-<p class="pubd">
-<span class="conf">US11741381B2</span><br> 
-    <span class="authors">V Kishore Ayyadevara;Sree Harsha Ankem;<b>Raghav Bali</b>;Rohan Khilnani;Vineet Shukla;Saikumar Chintareddy;Ranraj Rana Singh</span><br>
-    <span class="links">
-        <a target="_blank" href="https://patents.google.com/patent/US11741381B2/en?inventor=Raghav+Bali">Granted</a>
-    </span>
-</p>
-<hr>
-<a name="/patent5"></a>
-<h2 class="pubt">Sentiment progression analysis</h2>
-<p class="pubd">
-<span class="conf">US11256874B2</span><br> 
-    <span class="authors">Ninad D. Sathaye;<b>Raghav Bali</b>;Piyush Gupta;Krishnamohan Nandiraju</span><br>
-    <span class="links">
-        <a target="_blank" href="https://patents.google.com/patent/US11256874B2/en?inventor=Raghav+Bali">Granted</a>
-    </span>
-</p>
-<hr>
-<a name="/patent6"></a>
-<h2 class="pubt">Cybersecurity for sensitive-information utterances in interactive voice sessions using risk profiles</h2>
-<p class="pubd">
-<span class="conf">US20220199073A1</span><br> 
-    <span class="authors">Devikiran Ramadas;Gregory J Boss;Ninad Sathaye;<b>Raghav Bali</b>;Nitin Dwivedi</span><br>
-    <span class="links">
-        <a target="_blank" href="https://patents.google.com/patent/US20220199073A1/en?inventor=Raghav+Bali">Pending</a>
-    </span>
-</p>
-<hr>
-<a name="/patent7"></a>
-<h2 class="pubt">Routing of sensitive-information utterances through secure channels in interactive voice sessions</h2>
-<p class="pubd">
-<span class="conf">US20230269291A1</span><br> 
-    <span class="authors">Devikiran Ramadas;Ninad D. Sathaye;Gregory J. Boss;<b>Raghav Bali</b></span><br>
-    <span class="links">
-        <a target="_blank" href="https://patents.google.com/patent/US20230269291A1/en?inventor=Raghav+Bali">Pending</a>
-    </span>
-</p>
-<hr>
-<a name="/patent8"></a>
-<h2 class="pubt">Systems and methods for awakening a user based on sleep cycle</h2>
-<p class="pubd">
-<span class="conf">US20230059947A1</span><br> 
-    <span class="authors"><b>Raghav Bali</b>;Ninad D. Sathaye;Swapna Sourav Rout</span><br>
-    <span class="links">
-        <a target="_blank" href="https://patents.google.com/patent/US20230059947A1/en?inventor=Raghav+Bali">Pending</a>
-    </span>
-</p>
-<hr>
-<a name="/patent9"></a>
-<h2 class="pubt">Reinforcement learning machine learning models for intervention recommendation</h2>
-<p class="pubd">
-<span class="conf">US20230252338A1</span><br> 
-    <span class="authors">V. Kishore Ayyadevara;Rohan Khilnani;Swaroop S. Shekar;<b>Raghav Bali</b>;Joseph C. Cremaldi;Fritz T. Wilhelm;Vinod Burugupalli</span><br>
-    <span class="links">
-        <a target="_blank" href="https://patents.google.com/patent/US20230252338A1/en?inventor=Raghav+Bali">Pending</a>
-    </span>
-</p>
-<hr>
-<a name="/patent10"></a>
-<h2 class="pubt">Predictive document conversion</h2>
-<p class="pubd">
-<span class="conf">US20210326631A1</span><br> 
-    <span class="authors">Kartik Chaudhary;<b>Raghav Bali</b>;V Kishore Ayyadevara;Yerraguntla Yeshwanth Reddy</span><br>
-    <span class="links">
-        <a target="_blank" href="https://patents.google.com/patent/US20210326631A1/en?inventor=Raghav+Bali">Pending</a>
-    </span>
-</p>
-<hr>
-<a name="/patent11"></a>
-<h2 class="pubt">Predictive data analysis operations using a hierarchical intervention recommendation machine learning framework</h2>
-<p class="pubd">
-<span class="conf">US20230325690A1</span><br> 
-    <span class="authors">Ninad D. Sathaye;Manoj Kapoor;Gregory J. Boss;<b>Raghav Bali</b></span><br>
-    <span class="links">
-        <a target="_blank" href="https://patents.google.com/patent/US20230325690A1/en?inventor=Raghav+Bali">Pending</a>
-    </span>
-</p>
-<hr>
+{% endfor %}
 
 <a name="/talks"></a>
 
@@ -464,202 +229,27 @@ Outside of work, he’s a tech enthusiast who enjoys exploring new gadgets and i
 </div>
 <div class="row">
     <div class="col-xs-12">
-        <span class="conf">2025</span><br> 
+    {% assign talks_by_year = site.data.talks | group_by: "year" | sort: "name" | reverse %}
+    {% for year_group in talks_by_year %}
+        <span class="conf">{{ year_group.name }}</span><br>
         <ul>
+            {% for talk in year_group.items %}
             <li>
                 <div class="talkt">
-                        <a target="_blank" href="https://www.analyticsvidhya.com/datahacksummit-2025/workshops/mastering-llms-training-fine-tuning-and-best-practices-2">
-                            Mastering LLMs: Training, Fine-Tuning, and Best Practices
-                        </a>|
-                        <a target="_blank" href="https://github.com/raghavbali/mastering_llms_workshop">
-                        Github
-                        </a> |
-                        <a target="_blank" href="https://raghavbali.github.io/mastering_llms_workshop/">
-                        Workshop Website</a>
-                </div>
-            </li>
-        </ul>
-        <span class="conf">2024</span><br> 
-        <ul>
-            <li>
-                <div class="talkt">
-                        <a target="_blank" href="https://www.analyticsvidhya.com/datahacksummit/workshops/unleashing-llms-training-finetuning-and-evaluating">
-                            Unleashing LLMs: Training, Fine-Tuning and Evaluating
-                        </a>|
-                        <a target="_blank" href="https://github.com/raghavbali/llm_workshop">
-                        Github
+                        <a target="_blank" href="{{ talk.url }}">
+                            {{ talk.title }}
                         </a>
-                </div>
-            </li>
-            <li>
-                <div class="talkt">
-                    <a target="_blank" href="https://odsc.com/speakers/leveraging-llms-for-internal-knowledge-discovery/">
-                        Leveraging LLLMs for Internal Knowledge Discovery
-                    </a>|
-                    <a target="_blank" href="#">
-                    Github
-                    </a>
-                </div>
-            </li>
-        </ul>
-    <span class="conf">2023</span><br> 
-        <ul>
-            <li>
-                <div class="talkt">
-                    <a target="_blank" href="https://github.com/raghavbali/genai_landscape_odsc2023">
-                        ODSC APAC Session: Generative AI Landscape
-                    </a>|
-                    <a target="_blank" href="https://github.com/raghavbali/genai_landscape_odsc2023">
-                    Github
-                    </a>
-                 </div>
-            </li>
-            <li>
-                <div class="talkt">
-                    <a target="_blank" href="https://app.aiplus.training/courses/Hands-On-Generative-AI-Applications">
-                    ON-DEMAND WEBINAR: Lightning Interview "Hands-On Generative AI Applications"
-                    </a>|
-                    <a target="_blank" href="https://app.aiplus.training/courses/Hands-On-Generative-AI-Applications">
-                    ODSC On-Demand
-                    </a>
-                </div>
-            </li>
-            <li>
-                <div class="talkt">
-                        <a target="_blank" href="https://github.com/raghavbali/llm_workshop_dhs23">
-                            Analytics Vidhya DataHack Summit Workshop: Natural Language Processing using Generative Models
-                        </a>|
-                        <a target="_blank" href="https://github.com/raghavbali/llm_workshop_dhs23">
-                        Github
+                        {% for link in talk.links %}
+                        |
+                        <a target="_blank" href="{{ link.url }}">
+                        {{ link.text }}
                         </a>
+                        {% endfor %}
                 </div>
             </li>
-            <li>
-                <div class="talkt">
-                        <a target="_blank" href="https://github.com/raghavbali/building_robust_recsys_dhs23">
-                            Analytics Vidhya DataHack Summit Hack Session: Building Robust and Scalable Recommendation Systems for Online Food Delivery
-                        </a>|
-                        <a target="_blank" href="https://github.com/raghavbali/building_robust_recsys_dhs23">
-                        Github
-                        </a>
-                </div>
-            </li>
+            {% endfor %}
         </ul>
-    <span class="conf">2022</span><br> 
-        <ul>
-            <li>
-                <div class="talkt">
-                        <a target="_blank" href="https://github.com/raghavbali/workshop_text_classification">
-                            Image Generation with GANs with ODSC India
-                        </a>|
-                        <a target="_blank" href="https://github.com/raghavbali/gan_tutorial">
-                        Github
-                        </a>
-                </div> 
-            </li>
-            <li>
-                <div class="talkt">
-                    <a target="_blank" href="https://github.com/raghavbali/workshop_text_classification">
-                        NLP Workshop on Text Classification, 1729 Conference with Analytics Vidhya
-                    </a>|
-                    <a target="_blank" href="https://github.com/raghavbali/workshop_text_classification">
-                    Github
-                    </a>
-                </div>
-            </li>
-        </ul>
-    <span class="conf">2021</span><br> 
-        <ul>
-            <li>
-                <div class="talkt">
-                    <a target="_blank" href="https://github.com/raghavbali/transfer-learning-in-action/tree/master/chapter_1">
-                        Image Classification with Transfer Learning, Manning Publications Twitch Live-Stream
-                    </a>|
-                    <a target="_blank" href="https://www.twitch.tv/videos/1170692362">
-                    Video
-                    </a>
-                </div>
-            </li>
-            <li>
-                <div class="talkt">
-                    <a target="_blank" href="https://github.com/raghavbali/data_ketchup_gans">
-                        Image Generation with GANs, Kaggle Data Ketchup
-                    </a>|
-                    <a target="_blank" href="https://www.youtube.com/watch?v=J_33jSkFQis&ab_channel=KaggleDaysMeetupDelhiNCR">
-                    Video
-                    </a>
-                </div>
-            </li>
-            <li>
-                <div class="talkt">
-                    <a target="_blank" href="https://github.com/raghavbali/deep_fakes_tutorial">
-                        The Secret Ingredients to Train DeepFakes, ODSC APAC
-                    </a>|
-                    <a target="_blank" href="https://register.gotowebinar.com/register/7432238325978557965">
-                    Video
-                    </a>
-                </div>
-            </li>
-        </ul>
-    <span class="conf">2020</span><br> 
-        <ul>
-            <li>
-                <div class="talkt">
-                    <a target="_blank" href="https://github.com/raghavbali/nlp_starterpack_webinar">
-                        NLP Starter Pack, Analytics Vidhya Webinar
-                    </a>|
-                    <a target="_blank" href="https://www.facebook.com/watch/live/?v=337463904223866&ref=watch_permalink">
-                    Video
-                    </a>
-                </div>
-            </li>
-            <li>
-                <div class="talkt">
-                    <a target="_blank" href="https://github.com/raghavbali/text_generation">
-                        Text Generation using Deep Learning, Springboard Webinar
-                    </a>|
-                    <a target="_blank" href="https://www.youtube.com/watch?v=vSN5Tn38ZIc&ab_channel=SpringboardIndia">
-                    Video
-                    </a>
-                </div>
-            </li>
-        </ul>
-    <span class="conf">2019</span><br> 
-        <ul>
-            <li>
-                <div class="talkt">
-                    <a target="_blank" href="https://www.analyticsvidhya.com/datahack-summit-2019/schedule/hack-session-synthetic-text-data-generation-using-rnn-based-deep-learning-models/">
-                        Hack Session: Synthetic Text Data Generation using Recurrent Neural Networks (RNN)
-                    </a>|
-                    <a target="_blank" href="https://github.com/raghavbali/handwritten_text_dhs_av_2019">
-                        GitHub
-                    </a>
-                </div>
-            </li>
-            <li>
-                <div class="talkt">
-                    <a target="_blank" href="https://www.analyticsvidhya.com/datahack-summit-2019/schedule/workshop-applied-machine-learning/">
-                        Workshop: Applied Machine Learning
-                    </a>|
-                    <a target="_blank" href="https://github.com/raghavbali/appliedml_workshop_dhs_av_2019">
-                        GitHub
-                    </a>
-                </div>
-            </li>
-        </ul>
-    <span class="conf">2018</span><br> 
-        <ul>
-            <li>
-                <div class="talkt">
-                    <a target="_blank" href="https://www.analyticsvidhya.com/datahack-summit-2018/2018/08/04/getting-started-with-natural-language-processing/">
-                        Workshop: Getting Started With Natural Language Processing
-                    </a>|
-                    <a target="_blank" href="https://github.com/raghavbali/nlp_workshop_dhs18">
-                        GitHub
-                    </a>
-                </div>
-            </li>
-        </ul>
+    {% endfor %}
     </div>
 <!-- <div id="read-more-button">
     <a nohref>Read more</a>
@@ -669,17 +259,9 @@ Outside of work, he’s a tech enthusiast who enjoys exploring new gadgets and i
 <hr>
 
 # Articles
-  - [Supercharge Your LLM Apps Using DSPy and Langfuse](https://medium.com/data-science/supercharge-your-llm-apps-using-dspy-and-langfuse-f83c02ba96a1)
-  - [Efficient Object Detection with SSD and YoLO Models — A Comprehensive Beginner’s Guide (Part 3)](https://medium.com/towards-data-science/exploring-object-detection-with-r-cnn-models-a-comprehensive-beginners-guide-part-2-685bc89775e2)
-  - [Towards DataScience: Exploring Object Detection with R-CNN Models — A Comprehensive Beginner’s Guide (Part 2)](https://medium.com/towards-data-science/exploring-object-detection-with-r-cnn-models-a-comprehensive-beginners-guide-part-2-685bc89775e2)
-  - [Towards DataScience: Object Detection Basics — A Comprehensive Beginner’s Guide (Part 1)](https://medium.com/towards-data-science/object-detection-basics-a-comprehensive-beginners-guide-part-1-f57380c89b78)
-  - [Towards DataScience: Supercharge Training of your Deep Learning Models](https://medium.com/towards-data-science/supercharge-training-of-your-deep-learning-models-7168ff81a042)
-  - [PyDev of the Week](https://www.blog.pythonlibrary.org/2021/06/14/pydev-of-the-week-raghav-bali/)
-  - [Towards DataScience: Supercharge Image Classification with Transfer Learning](https://towardsdatascience.com/supercharge-image-classification-with-transfer-learning-4b8c52e69c0c)
-  - [Towards DataScience: Supercharge your Image Search with Transfer Learning](https://towardsdatascience.com/supercharge-your-image-search-with-transfer-learning-75dfb5d29ceb)
-  - [Towards DataScience: LSTMs for Music Generation](https://towardsdatascience.com/lstms-for-music-generation-8b65c9671d35)
-  - [Perceptron : Where It All Started](https://medium.com/@Rghv_Bali/perceptron-where-it-all-started-55d3508e38af)
-  - [Interview with Raghav Bali, Senior Data Scientist, United Health Group](https://www.digitalvidya.com/blog/interview-with-raghav-bali/)
+{% for article in site.data.articles %}
+  - [{{ article.title }}]({{ article.url }})
+{% endfor %}
   <!-- Dead Links -->
   <!-- - [CourseBricks: Introduction to Natural Language Processing](https://coursebricks.com/blog-introduction-to-natural-language-processing/) -->
   <!-- - [Top 25 Python Libraries for Machine Learning](https://www.zeolearn.com/magazine/python-libraries-for-machine-learning)


### PR DESCRIPTION
This PR refactors the `index.md` file to source its content from dedicated YAML files in the `_data/` directory. This separation of content and presentation improves maintainability and allows for easier updates.

**Changes:**
- Moved News items to `_data/news.yml`
- Moved Papers to `_data/papers.yml`
- Moved Authored Books to `_data/authored_books.yml`
- Moved Reviewed Books to `_data/reviewed_books.yml`
- Moved Patents to `_data/patents.yml`
- Moved Talks to `_data/talks.yml`
- Moved Articles to `_data/articles.yml`
- Updated `index.md` to iterate over these data files using Liquid templates.
- Ensured visual fidelity with the original design.

**Verification:**
- Generated a standalone HTML preview and verified the layout with a Playwright screenshot.
- Validated that all content was correctly migrated and rendered.

---
*PR created automatically by Jules for task [5995805501858346414](https://jules.google.com/task/5995805501858346414) started by @raghavbali*