### PR TITLE
Fix blog list alignment and mobile visibility

### DIFF
--- a/css/main_1603233531.css
+++ b/css/main_1603233531.css
@@ -107,7 +107,8 @@ ul.nav-bar li {
 
 .page-content .entries li {
   margin-bottom: 1.4em;
-  display: block;
+  display: flex;
+  flex-direction: column;
   padding-right: 0;
 }
 
@@ -116,11 +117,11 @@ ul.nav-bar li {
 }
 
 .page-content .entries span.date {
-  float: right;
   color: #91a3b0;
   font-size: 0.8em;
-  line-height: 2em;
+  line-height: 1.4em;
   text-transform: uppercase;
+  margin-top: 3px;
 }
 
 .page-content .entries .title {
@@ -131,9 +132,6 @@ ul.nav-bar li {
 }
 
 @media (max-width: 640px) {
-  .entries span.date {
-    display: none;
-  }
   .page-content .entries .title {
     font-size: 1.1em;
   }


### PR DESCRIPTION
This change updates the blog page layout to fix alignment issues caused by right-floated dates on long titles. The date is now displayed directly below the title as a subtitle, which provides a consistent layout across all screen sizes and ensures dates are visible on mobile devices.

---
*PR created automatically by Jules for task [8430035796169226460](https://jules.google.com/task/8430035796169226460) started by @raghavbali*