### PR TITLE
Merge articles and blog posts into single list on index.md

### DIFF
--- a/_data/articles.yml
+++ b/_data/articles.yml
@@ -1,22 +1,47 @@
 - title: Supercharge Your LLM Apps Using DSPy and Langfuse
   url: https://medium.com/data-science/supercharge-your-llm-apps-using-dspy-and-langfuse-f83c02ba96a1
-- title: "Efficient Object Detection with SSD and YoLO Models \u2014 A Comprehensive Beginner\u2019s Guide (Part 3)"
+  active: true
+- title: Efficient Object Detection with SSD and YoLO Models — A Comprehensive Beginner’s
+    Guide (Part 3)
   url: https://medium.com/towards-data-science/exploring-object-detection-with-r-cnn-models-a-comprehensive-beginners-guide-part-2-685bc89775e2
-- title: "Towards DataScience: Exploring Object Detection with R-CNN Models \u2014 A Comprehensive Beginner\u2019s Guide (Part 2)"
+  active: true
+- title: 'Towards DataScience: Exploring Object Detection with R-CNN Models — A Comprehensive
+    Beginner’s Guide (Part 2)'
   url: https://medium.com/towards-data-science/exploring-object-detection-with-r-cnn-models-a-comprehensive-beginners-guide-part-2-685bc89775e2
-- title: "Towards DataScience: Object Detection Basics\u200A\u2014\u200AA Comprehensive Beginner\u2019s Guide (Part 1)"
+  active: true
+- title: 'Towards DataScience: Object Detection Basics — A Comprehensive Beginner’s
+    Guide (Part 1)'
   url: https://medium.com/towards-data-science/object-detection-basics-a-comprehensive-beginners-guide-part-1-f57380c89b78
+  active: true
 - title: 'Towards DataScience: Supercharge Training of your Deep Learning Models'
   url: https://medium.com/towards-data-science/supercharge-training-of-your-deep-learning-models-7168ff81a042
-- title: PyDev of the Week
-  url: https://www.blog.pythonlibrary.org/2021/06/14/pydev-of-the-week-raghav-bali/
+  active: true
 - title: 'Towards DataScience: Supercharge Image Classification with Transfer Learning'
   url: https://towardsdatascience.com/supercharge-image-classification-with-transfer-learning-4b8c52e69c0c
+  active: true
 - title: 'Towards DataScience: Supercharge your Image Search with Transfer Learning'
   url: https://towardsdatascience.com/supercharge-your-image-search-with-transfer-learning-75dfb5d29ceb
+  active: true
 - title: 'Towards DataScience: LSTMs for Music Generation'
   url: https://towardsdatascience.com/lstms-for-music-generation-8b65c9671d35
+  active: true
 - title: 'Perceptron : Where It All Started'
   url: https://medium.com/@Rghv_Bali/perceptron-where-it-all-started-55d3508e38af
+  active: true
+- title: 'CourseBricks: Introduction to Natural Language Processing'
+  url: https://coursebricks.com/blog-introduction-to-natural-language-processing/
+  active: false
+- title: Top 25 Python Libraries for Machine Learning
+  url: https://www.zeolearn.com/magazine/python-libraries-for-machine-learning
+  active: false
+- title: How to Become a Data Scientist
+  url: https://www.zeolearn.com/magazine/how-to-become-a-data-scientist
+  active: false
+- title: PyDev of the Week
+  url: https://www.blog.pythonlibrary.org/2021/06/14/pydev-of-the-week-raghav-bali/
+  active: true
+  date: '2021-06-14'
 - title: Interview with Raghav Bali, Senior Data Scientist, United Health Group
   url: https://www.digitalvidya.com/blog/interview-with-raghav-bali/
+  active: true
+  date: '2019-11-20'

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -51,7 +51,8 @@
                             <li><a href="/#/books">Books</a></li>
                             <li><a href="/#/patents">Patents</a></li>
                             <li><a href="/#/talks">Talks</a></li>
-                            <li><a href="/blog">Blog</a></li>
+                            <li><a href="/#/articles">Articles</a></li>
+                            <!-- <li><a href="/blog">Blog</a></li> -->
                             <!-- <li><a target="_blank" href="https://github.com/raghavbali">GitHub</a></li> -->
                             <li class="hide-link-on-small-screens"><a href="/bookshelf">Bookshelf</a></li>
                         </ul>

--- a/_pages/old.md
+++ b/_pages/old.md
@@ -6,6 +6,7 @@ permalink:  /blog/
 
 <div class="row">
     <div class="col-xs-12">
+        <p>This page is not rendered anymore, all article links are rendered on index.md</p>
         <ul class="entries">
             {% for post in site.posts %}
                 <li>

--- a/index.md
+++ b/index.md
@@ -127,7 +127,7 @@ During his Master’s, Raghav took on exciting courses like Machine Learning, So
 
 Outside of work, he’s a tech enthusiast who enjoys exploring new gadgets and ideas. He’s also a passionate photographer—check out his work on [Instagram](https://www.instagram.com/raghavbali/) and [VSCO](https://vsco.co/raghavbali/gallery).
 
-[Occassional Blog Posts](/blog)
+[Occassional Blog Posts](#/articles)
 
 ---
 
@@ -258,14 +258,55 @@ Outside of work, he’s a tech enthusiast who enjoys exploring new gadgets and i
 
 <hr>
 
+<a name="/articles"></a>
 # Articles
-{% for article in site.data.articles %}
-  - [{{ article.title }}]({{ article.url }})
-{% endfor %}
-  <!-- Dead Links -->
-  <!-- - [CourseBricks: Introduction to Natural Language Processing](https://coursebricks.com/blog-introduction-to-natural-language-processing/) -->
-  <!-- - [Top 25 Python Libraries for Machine Learning](https://www.zeolearn.com/magazine/python-libraries-for-machine-learning)
-  - [How to Become a Data Scientist](https://www.zeolearn.com/magazine/how-to-become-a-data-scientist) -->
+
+<div class="row">
+    <div class="col-xs-12">
+        <ul class="entries">
+            {% assign undated_articles = "" | split: "" %}
+            {% assign dated_articles = "" | split: "" %}
+
+            {% for article in site.data.articles %}
+                {% if article.active != false %}
+                    {% if article.date %}
+                        {% assign dated_articles = dated_articles | push: article %}
+                    {% else %}
+                        {% assign undated_articles = undated_articles | push: article %}
+                    {% endif %}
+                {% endif %}
+            {% endfor %}
+
+            {% assign all_dated = site.posts | concat: dated_articles | sort: "date" | reverse %}
+            {% assign all_items = undated_articles | concat: all_dated %}
+
+            {% for item in all_items %}
+                <li>
+                    <span class="title">
+                        {% if item.layout == 'post' %}
+                            <i class="bi bi-github"></i>
+                            {% assign item_url = item.url %}
+                            {% assign link_target = "" %}
+                        {% else %}
+                            {% if item.url contains "medium.com" or item.url contains "towardsdatascience.com" %}
+                                <i class="bi bi-medium"></i>
+                            {% else %}
+                                🔗
+                            {% endif %}
+                            {% assign item_url = item.url %}
+                            {% assign link_target = 'target="_blank"' %}
+                        {% endif %}
+                        &nbsp;
+                        <a {{ link_target }} href="{{ item_url }}">{{ item.title }}</a>
+                    </span>
+                    {% if item.date %}
+                    <span class="date">{{ item.date | date: "%d %B %Y" }}</span>
+                    {% endif %}
+                </li>
+            {% endfor %}
+        </ul>
+    </div>
+</div>
   
 
 <!-- <div id="read-more-button">


### PR DESCRIPTION
This PR merges the external articles list (from `_data/articles.yml`) and local blog posts (from `site.posts`) into a single "Articles" section on the main page (`index.md`).

Key Changes:
1.  **Data Update**: `_data/articles.yml` was updated to include publication dates (fetched from URLs where possible) and an `active` flag. Commented-out articles from `index.md` were moved to this file as inactive entries.
2.  **Frontend Logic**: 
    - The "Articles" section now renders a combined list.
    - Sorting logic: Undated articles appear first, followed by dated articles sorted chronologically (newest first).
    - Icons: Self-hosted posts use a GitHub icon. Medium/TowardsDataScience links use a Medium icon. Other external links use a generic link emoji (🔗).
    - Style: Matches the previous blog page style (Title on top, Date below).
3.  **Navigation**:
    - Top navigation "Blog" link is replaced/hidden in favor of "Articles" pointing to the main page section.
    - "Occasional Blog Posts" link on the main page now points to the Articles section.
    - The separate blog page (`/blog/`) now displays a deprecation notice.

Verification:
- A screenshot was generated to verify the rendering of the merged list, correct sorting, icon usage, and styling.
- Navigation links were updated in the layout.

---
*PR created automatically by Jules for task [10496920922058432844](https://jules.google.com/task/10496920922058432844) started by @raghavbali*