### PR TITLE
Fix Jekyll build errors: YAML syntax and date sorting type mismatch

### DIFF
--- a/_data/articles.yml
+++ b/_data/articles.yml
@@ -40,8 +40,8 @@
 - title: PyDev of the Week
   url: https://www.blog.pythonlibrary.org/2021/06/14/pydev-of-the-week-raghav-bali/
   active: true
-  date: '2021-06-14'
+  date: 2021-06-14 00:00:00 +0000
 - title: Interview with Raghav Bali, Senior Data Scientist, United Health Group
   url: https://www.digitalvidya.com/blog/interview-with-raghav-bali/
   active: true
-  date: '2019-11-20'
+  date: 2019-11-20 00:00:00 +0000

--- a/_posts/2016-12-30-perceptron.markdown
+++ b/_posts/2016-12-30-perceptron.markdown
@@ -3,7 +3,7 @@ layout: post
 title:  "Classification using Percentron"
 date:   2016-12-30 10:22:34 +0530
 categories: general
-excerpt:    "The meaning of the word perceptron as per the English dictionary is "a computer model or computerized machine devised to represent or simulate the ability of the brain to recognize and discriminate"
+excerpt:    'The meaning of the word perceptron as per the English dictionary is "a computer model or computerized machine devised to represent or simulate the ability of the brain to recognize and discriminate"'
 ---
 
 This definition holds pretty true even when we talk in the context of Machine Learning. A Perceptron is a _Supervised Classification_ algorithm.


### PR DESCRIPTION
This PR addresses the build failures reported in the GitHub Actions log following PR #32.

### Changes
1.  **Fixed YAML Syntax Error:** Corrected `_posts/2016-12-30-perceptron.markdown` where nested double quotes in the `excerpt` field caused a parsing error.
2.  **Fixed Date Sorting Error:** Updated date entries in `_data/articles.yml` to use unquoted timestamps. This ensures compatibility with Jekyll's `site.posts` (Time objects) when sorting the combined list in `index.md`, preventing the "comparison of Array with Array failed" (Liquid/Ruby type mismatch) error.

### Verification
- Validated the fix using a Python script that simulated the Liquid/Jekyll data loading and sorting logic. The script confirmed that standardizing the date formats resolves the sorting failure.
- Confirmed that the YAML parser no longer errors on the Perceptron post.

---
*PR created automatically by Jules for task [13489245835149129030](https://jules.google.com/task/13489245835149129030) started by @raghavbali*