### PR TITLE
Design refresh: Dark mode, Footer, Home, Nav

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -27,8 +27,9 @@
         </main>
 
         <footer class="footer">
-            <small>&copy; {{ site.time | date: '%Y' }} Raghav Bali. All rights reserved.</small>
+            <small>&copy; {{ site.time | date: '%Y' }} Raghav Bali. All rights reserved. Inspired by <a href="https://markdotto.com/" target="_blank">@mdo</a>.</small>
         </footer>
     </div>
+    <script src="{{ '/js/theme.js' | relative_url }}"></script>
 </body>
 </html>

--- a/blog.html
+++ b/blog.html
@@ -4,8 +4,15 @@ title: Blog
 permalink: /blog/
 ---
 
+<nav class="sub-nav">
+    <ul>
+        <li><a href="#articles">Articles</a></li>
+        <li><a href="#talks">Talks</a></li>
+    </ul>
+</nav>
+
 <div class="mb-5">
-    <h2>Articles</h2>
+    <h2 id="articles">Articles</h2>
     <ul class="list-unstyled">
         {% assign undated_articles = "" | split: "" %}
         {% assign dated_articles = "" | split: "" %}
@@ -48,7 +55,11 @@ permalink: /blog/
 <hr>
 
 <div class="mb-5">
-    <h2>Talks</h2>
+    <h2 id="talks">Talks</h2>
+    <div style="display: flex; gap: 2rem; margin-bottom: 2rem;">
+         <div style="flex: 1;"><img src="{{ '/img/talks/talk_2023.jpg' | relative_url }}" class="img-fluid" alt="Talk 2023"></div>
+         <div style="flex: 1;"><img src="{{ '/img/talks/talk_2019.jpeg' | relative_url }}" class="img-fluid" alt="Talk 2019"></div>
+    </div>
     {% assign talks_by_year = site.data.talks | group_by: "year" | sort: "name" | reverse %}
     {% for year_group in talks_by_year %}
     <h3 class="h5 mt-4">{{ year_group.name }}</h3>

--- a/css/main.css
+++ b/css/main.css
@@ -21,6 +21,16 @@
     }
 }
 
+body.dark-theme {
+    --bg-color: #111;
+    --text-color: #eee;
+    --text-muted: #aaa;
+    --link-color: #66b3ff;
+    --link-hover-color: #99ccff;
+    --border-color: #333;
+    --code-bg: #222;
+}
+
 body {
     font-family: var(--font-family);
     background-color: var(--bg-color);
@@ -112,6 +122,10 @@ a:hover {
 
 .grid-item {
     margin-bottom: 2rem;
+}
+
+.grid-3 {
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
 }
 
 /* Lists */
@@ -222,4 +236,36 @@ h1, h2, h3, h4, h5, h6 {
 .pub-meta {
     color: var(--text-muted);
     font-size: 0.9rem;
+}
+
+/* Sub Navigation */
+.sub-nav {
+    position: -webkit-sticky;
+    position: sticky;
+    top: 0;
+    background-color: var(--bg-color);
+    z-index: 100;
+    padding: 1rem 0;
+    border-bottom: 1px solid var(--border-color);
+    margin-bottom: 2rem;
+}
+
+.sub-nav ul {
+    display: flex;
+    gap: 1.5rem;
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    overflow-x: auto;
+    white-space: nowrap;
+}
+
+.sub-nav a {
+    color: var(--text-muted);
+    font-weight: 500;
+}
+
+.sub-nav a:hover {
+    color: var(--text-color);
+    text-decoration: none;
 }

--- a/index.html
+++ b/index.html
@@ -32,8 +32,8 @@ title: Home
             <h3>Latest Books</h3>
             <a href="{{ '/work' | relative_url }}">View all</a>
         </div>
-        <div class="grid">
-            {% for book in site.data.authored_books limit:2 %}
+        <div class="grid grid-3">
+            {% for book in site.data.authored_books limit:3 %}
             <div class="grid-item">
                 <a href="{{ book.url }}" target="_blank" style="text-decoration: none; color: inherit;">
                     <img src="{{ book.image | relative_url }}" alt="{{ book.title }}" class="img-fluid mb-2" style="max-height: 200px;">

--- a/js/theme.js
+++ b/js/theme.js
@@ -1,0 +1,21 @@
+(function() {
+    function updateTheme() {
+        var hour = new Date().getHours();
+        var isNight = hour >= 19 || hour < 7;
+        var systemDark = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches;
+
+        if (isNight || systemDark) {
+            document.body.classList.add('dark-theme');
+        } else {
+            document.body.classList.remove('dark-theme');
+        }
+    }
+
+    // Run on load (assumes script is defer or at end of body, or run immediately if in head to set class asap to avoid flash, but body must exist)
+    // If in head, we might need to wait for body.
+    if (document.body) {
+        updateTheme();
+    } else {
+        document.addEventListener('DOMContentLoaded', updateTheme);
+    }
+})();

--- a/work.html
+++ b/work.html
@@ -4,8 +4,17 @@ title: Work
 permalink: /work/
 ---
 
+<nav class="sub-nav">
+    <ul>
+        <li><a href="#books">Books</a></li>
+        <li><a href="#reviewed">Reviewed</a></li>
+        <li><a href="#papers">Papers</a></li>
+        <li><a href="#patents">Patents</a></li>
+    </ul>
+</nav>
+
 <div class="mb-5">
-    <h2>Books</h2>
+    <h2 id="books">Books</h2>
     <div class="grid">
         {% for book in site.data.authored_books %}
         <div class="grid-item">
@@ -24,7 +33,7 @@ permalink: /work/
 </div>
 
 <div class="mb-5">
-    <h2>Books Reviewed</h2>
+    <h2 id="reviewed">Books Reviewed</h2>
     <ul class="list-unstyled">
         {% for book in site.data.reviewed_books %}
         <li class="list-item">
@@ -38,7 +47,7 @@ permalink: /work/
 
 <div class="row" style="display: flex; flex-wrap: wrap; margin-left: -15px; margin-right: -15px;">
     <div class="col-md-6 mb-5" style="flex: 0 0 100%; max-width: 100%; padding-left: 15px; padding-right: 15px;">
-        <h2>Papers</h2>
+        <h2 id="papers">Papers</h2>
         {% for paper in site.data.papers %}
         <div class="mb-4">
             <h4 class="h5 pub-title">{{ paper.title }}</h4>
@@ -61,7 +70,7 @@ permalink: /work/
     </div>
 
     <div class="col-md-6 mb-5" style="flex: 0 0 100%; max-width: 100%; padding-left: 15px; padding-right: 15px;">
-        <h2>Patents</h2>
+        <h2 id="patents">Patents</h2>
         {% for patent in site.data.patents %}
         <div class="mb-4">
             <h4 class="h5 pub-title">{{ patent.title }}</h4>


### PR DESCRIPTION
Implemented several design updates:
1.  **Dark Mode:** Added time-based (7pm-7am) and system-preference aware dark mode via `js/theme.js` and CSS variables.
2.  **Footer:** Added 'Inspired by @mdo' credit.
3.  **Home Page:** Compacted 'Latest Books' section to show 3 items in a 3-column grid.
4.  **Navigation:** Added sticky sub-navigation to Work and Blog pages.
5.  **Blog:** Restored side-by-side talks images.

Verified via static HTML generation and Playwright screenshots.

---
*PR created automatically by Jules for task [4913352005459449791](https://jules.google.com/task/4913352005459449791) started by @raghavbali*