### PR TITLE
Refine Homepage Hero Section to Match Mark Dotto Style

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -166,15 +166,37 @@ a:hover {
     }
 }
 
-.hero-avatar img {
-    width: 160px;
-    height: 160px;
+.hero .hero-avatar img {
+    width: 320px;
+    aspect-ratio: 1 / 1;
     border-radius: 50%;
     object-fit: cover;
+    max-width: 100%;
 }
 
 .hero-content {
     flex: 1;
+    display: flex;
+    flex-direction: column;
+    justify-content: center; /* Center vertically against the large image */
+}
+
+@media (max-width: 767.98px) {
+    .hero {
+        align-items: center;
+        text-align: center;
+    }
+
+    .social-links {
+        justify-content: center;
+    }
+}
+
+.hero-content .lead {
+    font-size: 1rem; /* Reduced from 1.2rem */
+    color: var(--text-muted);
+    margin-bottom: 1rem;
+    margin-top: -0.5rem; /* Reduce spacing between Name and Subtitle */
 }
 
 .social-links {

--- a/index.html
+++ b/index.html
@@ -9,7 +9,7 @@ title: Home
     </div>
     <div class="hero-content">
         <h1>{{ site.author.name }}</h1>
-        <p class="lead" style="font-size: 1.2rem; color: var(--text-muted);">Principal Data Scientist at Delivery Hero. Author. Shutterbug.</p>
+        <p class="lead">Principal Data Scientist at Delivery Hero. Author. Shutterbug.</p>
         <p>
             I focus on researching and building enterprise-grade solutions using Machine Learning, Deep Learning, and Natural Language Processing for real-world challenges.
         </p>


### PR DESCRIPTION
- Updated the homepage hero section to feature a larger, circular avatar (320px).
- Implemented `aspect-ratio: 1/1` for robust circular cropping of the profile image.
- Added responsive styles to center the bio text and social links on mobile devices, matching the requested aesthetic.
- Cleaned up `index.html` image attributes.
- Verified using Playwright screenshots for both desktop and mobile layouts.

---
*PR created automatically by Jules for task [10977812852338240230](https://jules.google.com/task/10977812852338240230) started by @raghavbali*