### PR TITLE
Refactor navigation, create Talks page, and update layouts

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -16,7 +16,8 @@
             </h3>
             <nav class="nav">
                 <a href="{{ '/' | relative_url }}" class="nav-link {% if page.url == '/' %}active{% endif %}">Home</a>
-                <a href="{{ '/work' | relative_url }}" class="nav-link {% if page.url contains '/work' %}active{% endif %}">Work</a>
+                <a href="{{ '/published-works' | relative_url }}" class="nav-link {% if page.url contains '/published-works' %}active{% endif %}">Published Works</a>
+                <a href="{{ '/talks' | relative_url }}" class="nav-link {% if page.url contains '/talks' %}active{% endif %}">Talks</a>
                 <a href="{{ '/blog' | relative_url }}" class="nav-link {% if page.url contains '/blog' %}active{% endif %}">Blog</a>
                 <a href="{{ '/bookshelf' | relative_url }}" class="nav-link {% if page.url contains '/bookshelf' %}active{% endif %}">BookShelf</a>
                 <a href="{{ '/about' | relative_url }}" class="nav-link {% if page.url contains '/about' %}active{% endif %}">About</a>

--- a/blog.html
+++ b/blog.html
@@ -4,15 +4,7 @@ title: Blog
 permalink: /blog/
 ---
 
-<nav class="sub-nav">
-    <ul>
-        <li><a href="#articles">Articles</a></li>
-        <li><a href="#talks">Talks</a></li>
-    </ul>
-</nav>
-
 <div class="mb-5">
-    <h2 id="articles">Articles</h2>
     <ul class="list-unstyled">
         {% assign undated_articles = "" | split: "" %}
         {% assign dated_articles = "" | split: "" %}
@@ -50,33 +42,4 @@ permalink: /blog/
         </li>
         {% endfor %}
     </ul>
-</div>
-
-<hr>
-
-<div class="mb-5">
-    <h2 id="talks">Talks</h2>
-    <div style="display: flex; gap: 2rem; margin-bottom: 2rem;">
-         <div style="flex: 1;"><img src="{{ '/img/talks/talk_2023.jpg' | relative_url }}" class="img-fluid" alt="Talk 2023"></div>
-         <div style="flex: 1;"><img src="{{ '/img/talks/talk_2019.jpeg' | relative_url }}" class="img-fluid" alt="Talk 2019"></div>
-    </div>
-    {% assign talks_by_year = site.data.talks | group_by: "year" | sort: "name" | reverse %}
-    {% for year_group in talks_by_year %}
-    <h3 class="h5 mt-4">{{ year_group.name }}</h3>
-    <ul class="list-unstyled">
-        {% for talk in year_group.items %}
-        <li class="list-item">
-            <a href="{{ talk.url }}" target="_blank" class="list-item-title">{{ talk.title }}</a>
-            {% if talk.links %}
-            <div class="list-item-meta">
-                {% for link in talk.links %}
-                <a href="{{ link.url }}" target="_blank">{{ link.text }}</a>
-                {% unless forloop.last %} | {% endunless %}
-                {% endfor %}
-            </div>
-            {% endif %}
-        </li>
-        {% endfor %}
-    </ul>
-    {% endfor %}
 </div>

--- a/bookshelf.html
+++ b/bookshelf.html
@@ -7,9 +7,10 @@ permalink: /bookshelf/
 <div class="bookshelf-container">
 
     <div class="book-list">
-        <h3>Currently Reading</h3>
-        {% for book in site.data.books %}
-        {% if book.status == 'reading' %}
+        <div class="mb-5">
+            <h3>Currently Reading</h3>
+            {% for book in site.data.books %}
+            {% if book.status == 'reading' %}
         <div class="book-item">
             <div class="book-info">
                 <a href="{{ book.url }}" target="_blank" class="book-title">
@@ -23,13 +24,15 @@ permalink: /bookshelf/
                 </a>
             </div>
             {% endif %}
+            </div>
+            {% endif %}
+            {% endfor %}
         </div>
-        {% endif %}
-        {% endfor %}
 
-        <h3>Books with Reviews</h3>
-        {% for book in site.data.books %}
-        {% if book.review_url %}
+        <div class="mb-5">
+            <h3>Books with Reviews</h3>
+            {% for book in site.data.books %}
+            {% if book.review_url %}
         <div class="book-item">
             <div class="book-info">
                 <a href="{{ book.url }}" target="_blank" class="book-title">
@@ -41,9 +44,10 @@ permalink: /bookshelf/
                     <i class="bi bi-bookmark-star-fill"></i>
                 </a>
             </div>
+            </div>
+            {% endif %}
+            {% endfor %}
         </div>
-        {% endif %}
-        {% endfor %}
     </div>
 
     <div class="goodreads-widget-container">

--- a/published-works.html
+++ b/published-works.html
@@ -1,7 +1,7 @@
 ---
 layout: default
-title: Work
-permalink: /work/
+title: Published Works
+permalink: /published-works/
 ---
 
 <nav class="sub-nav">

--- a/talks.html
+++ b/talks.html
@@ -1,0 +1,31 @@
+---
+layout: default
+title: Talks
+permalink: /talks/
+---
+
+<div class="mb-5">
+    <div style="display: flex; gap: 2rem; margin-bottom: 2rem;">
+         <div style="flex: 1;"><img src="{{ '/img/talks/talk_2023.jpg' | relative_url }}" class="img-fluid" alt="Talk 2023"></div>
+         <div style="flex: 1;"><img src="{{ '/img/talks/talk_2019.jpeg' | relative_url }}" class="img-fluid" alt="Talk 2019"></div>
+    </div>
+    {% assign talks_by_year = site.data.talks | group_by: "year" | sort: "name" | reverse %}
+    {% for year_group in talks_by_year %}
+    <h3 class="h5 mt-4">{{ year_group.name }}</h3>
+    <ul class="list-unstyled">
+        {% for talk in year_group.items %}
+        <li class="list-item">
+            <a href="{{ talk.url }}" target="_blank" class="list-item-title">{{ talk.title }}</a>
+            {% if talk.links %}
+            <div class="list-item-meta">
+                {% for link in talk.links %}
+                <a href="{{ link.url }}" target="_blank">{{ link.text }}</a>
+                {% unless forloop.last %} | {% endunless %}
+                {% endfor %}
+            </div>
+            {% endif %}
+        </li>
+        {% endfor %}
+    </ul>
+    {% endfor %}
+</div>


### PR DESCRIPTION
This PR addresses the requested layout updates:
1. Renamed "Work" to "Published Works" (both link, file, and permalink).
2. Added a new "Talks" section to the main navigation.
3. Created a new `talks.html` page and migrated the Talks content over from the Blog page.
4. Cleaned up the Blog page by removing the sub-navigation menu and the obsolete "Articles" header.
5. Fixed alignment issues on the Bookshelf page by applying consistent margin (`mb-5`) wrappers to the book list sections.

Visual verification screenshots have been taken to confirm layout rendering.

---
*PR created automatically by Jules for task [8978155567147918613](https://jules.google.com/task/8978155567147918613) started by @raghavbali*